### PR TITLE
Quote the email subject by default in the task input field

### DIFF
--- a/custom-button.tb2taskwarrior
+++ b/custom-button.tb2taskwarrior
@@ -7,8 +7,8 @@
 var taskPath = "/usr/bin/xterm";
 
 var messageUri = gFolderDisplay.selectedMessageUris[0];
-var msgHdr = messenger.messageServiceFromURI(messageUri).messageURIToMsgHdr(messageUri); 
-var box = custombuttons.promptBox("Add task", "Modify the title or add more attributes \n(e.g. due:tomorrow, pro:Party)", msgHdr.mime2DecodedSubject);
+var msgHdr = messenger.messageServiceFromURI(messageUri).messageURIToMsgHdr(messageUri);
+var box = custombuttons.promptBox("Add task", "Modify the title or add more attributes \n(e.g. due:tomorrow, pro:Party)", '"' + msgHdr.mime2DecodedSubject + '"');
 if(box[0])
 {
 	// change arguments to task


### PR DESCRIPTION
I often found that the subject lines of the emails I needed to add as tasks would have special chars in them that would break the add command that was run. To work around this I have quoted the subject line by default in the text input.

This is to stop complex email subjects from breaking the add command.
